### PR TITLE
Improve lcgm jamovi cache lifecycle

### DIFF
--- a/R/lcgm.b.R
+++ b/R/lcgm.b.R
@@ -1,86 +1,102 @@
-
-# This file is a generated template, your changes will not be overwritten
+# 변경 요약: 캐시 무효화/정리 루틴과 데이터 접근 헬퍼를 도입하여 중복 객체를 줄이고 실행 후 대용량 상태를 해제합니다.
 #' @importFrom magrittr %>%
 
 lcgmClass <- if (requireNamespace('jmvcore', quietly = TRUE))
   R6::R6Class(
     "lcgmClass",
     inherit = lcgmBase,
-    
+
     active = list(
-      
+
       res = function() {
-        if (is.null(private$.res_cache)) {
-          data <- self$data
-          if (self$options$miss == 'listwise')
-            data <- jmvcore::naOmit(data)
-          private$.res_cache <- tidySEM::mx_growth_mixture(
-            model      = self$options$model,
-            data       = as.data.frame(data),
-            classes    = self$options$nc,
-            thresholds = self$options$thr
-          )
-        }
-        private$.res_cache
+        cache <- private$.cacheGet("res")
+        if (!is.null(cache))
+          return(cache)
+
+        data <- private$.data_model()
+        result <- tidySEM::mx_growth_mixture(
+          model      = self$options$model,
+          data       = data,
+          classes    = self$options$nc,
+          thresholds = self$options$thr
+        )
+
+        private$.cacheSet("res", result)
+        result
       },
-      
+
       desc = function() {
-        if (is.null(private$.desc_cache)) {
-          data <- self$data
-          private$.desc_cache <- tidySEM::descriptives(data)[,
-                                                             c("name","n","missing","mean","median","sd","min","max")]
-        }
-        private$.desc_cache
+        cache <- private$.cacheGet("desc")
+        if (!is.null(cache))
+          return(cache)
+
+        data <- private$.data_raw()
+        desc_df <- tidySEM::descriptives(data)
+        cols <- c("name", "n", "missing", "mean", "median", "sd", "min", "max")
+        desc_df <- desc_df[, cols, drop = FALSE]
+        rownames(desc_df) <- desc_df$name
+
+        private$.cacheSet("desc", desc_df)
+        desc_df
       },
-      
+
       fit = function() {
-        if (is.null(private$.fit_cache))
-          private$.fit_cache <- tidySEM::table_fit(self$res)
-        private$.fit_cache
+        cache <- private$.cacheGet("fit")
+        if (!is.null(cache))
+          return(cache)
+
+        fit_tbl <- tidySEM::table_fit(self$res)
+        private$.cacheSet("fit", fit_tbl)
+        fit_tbl
       },
-      
+
       parameters = function() {
-        if (is.null(private$.para_cache)) {
-          para <- tidySEM::table_results(self$res, columns = NULL)
-          private$.para_cache <- para[para$Category %in% c("Means","Variances"),
-                                      c("Category","lhs","est","se","pval","confint","name")]
-        }
-        private$.para_cache
+        cache <- private$.cacheGet("parameters")
+        if (!is.null(cache))
+          return(cache)
+
+        para <- tidySEM::table_results(self$res, columns = NULL)
+        keep <- para$Category %in% c("Means", "Variances")
+        cols <- c("Category", "lhs", "est", "se", "pval", "confint", "name")
+        para <- para[keep, cols, drop = FALSE]
+
+        private$.cacheSet("parameters", para)
+        para
       },
-      
+
       classProbabilities = function() {
-        if (is.null(private$.cp_cache)) {
-          cp1 <- tidySEM::class_prob(self$res)
-          individual_data <- data.frame(cp1$individual)   # predicted & posterior probs
-          predicted_classes <- individual_data$predicted
-          
-          class_counts <- table(predicted_classes)
-          total_n <- sum(class_counts)
-          
-          summary_df <- data.frame(
-            Class = as.numeric(names(class_counts)),
-            Count = as.numeric(class_counts),
-            Proportion = round(as.numeric(class_counts) / total_n, 3)
-          )
-          
-          private$.cp_cache <- list(
-            summary    = summary_df,
-            individual = individual_data
-          )
-        }
-        private$.cp_cache
+        cache <- private$.cacheGet("classProbabilities")
+        if (!is.null(cache))
+          return(cache)
+
+        cp_raw <- tidySEM::class_prob(self$res)
+        individual <- private$.normalizeIndividual(cp_raw$individual)
+
+        predicted_classes <- individual$predicted
+        class_counts <- table(predicted_classes)
+        total_n <- sum(class_counts)
+
+        summary_df <- data.frame(
+          Class = as.numeric(names(class_counts)),
+          Count = as.numeric(class_counts),
+          Proportion = round(as.numeric(class_counts) / total_n, 3),
+          stringsAsFactors = FALSE
+        )
+
+        result <- list(
+          summary    = summary_df,
+          individual = individual
+        )
+
+        private$.cacheSet("classProbabilities", result)
+        result
       }
     ),
-    
+
     private = list(
-      .htmlwidget   = NULL,
-      .res_cache    = NULL,
-      .desc_cache   = NULL,
-      .fit_cache    = NULL,
-      .para_cache   = NULL,
-      .cp_cache     = NULL,
-      
-      # ---------- 안전 텍스트 출력 ----------
+      .htmlwidget = NULL,
+      .cache_env = NULL,
+
       .setTextSafe = function(txt) {
         slots <- c("three", "threeStep", "threeStepText", "text1", "text", "auxText")
         for (id in slots) {
@@ -93,34 +109,104 @@ lcgmClass <- if (requireNamespace('jmvcore', quietly = TRUE))
         try(self$results$instructions$setContent(txt), silent = TRUE)
         invisible(TRUE)
       },
-      
-      # ---------- 3-STEP 계산 (효과크기 + 다중비교 보정 포함) ----------
+
+      .cacheEnsure = function() {
+        if (is.null(private$.cache_env))
+          private$.cache_env <- new.env(parent = emptyenv())
+      },
+
+      .cacheGet = function(key) {
+        private$.cacheEnsure()
+        if (exists(key, envir = private$.cache_env, inherits = FALSE))
+          get(key, envir = private$.cache_env, inherits = FALSE)
+        else
+          NULL
+      },
+
+      .cacheSet = function(key, value) {
+        private$.cacheEnsure()
+        if (is.null(value)) {
+          if (exists(key, envir = private$.cache_env, inherits = FALSE))
+            rm(list = key, envir = private$.cache_env)
+          return(NULL)
+        }
+        assign(key, value, envir = private$.cache_env)
+        value
+      },
+
+      .cacheReset = function(keys = NULL) {
+        private$.cacheEnsure()
+        if (is.null(keys)) {
+          rm(list = ls(envir = private$.cache_env, all.names = TRUE), envir = private$.cache_env)
+        } else {
+          keys <- intersect(keys, ls(envir = private$.cache_env, all.names = TRUE))
+          if (length(keys) > 0)
+            rm(list = keys, envir = private$.cache_env)
+        }
+        invisible(TRUE)
+      },
+
+      .data_raw = function() {
+        cache <- private$.cacheGet("data_raw")
+        if (!is.null(cache))
+          return(cache)
+
+        df <- as.data.frame(self$data)
+        private$.cacheSet("data_raw", df)
+        df
+      },
+
+      .data_model = function() {
+        cache <- private$.cacheGet("data_model")
+        if (!is.null(cache))
+          return(cache)
+
+        df <- private$.data_raw()
+        if (identical(self$options$miss, 'listwise'))
+          df <- jmvcore::naOmit(df)
+
+        private$.cacheSet("data_model", df)
+        df
+      },
+
+      .normalizeIndividual = function(x) {
+        if (!is.data.frame(x))
+          x <- as.data.frame(x)
+        rownames(x) <- NULL
+        if (!"predicted" %in% names(x) && "Predicted" %in% names(x))
+          names(x)[names(x) == "Predicted"] <- "predicted"
+        if (!is.null(x$predicted)) {
+          x$predicted <- as.integer(x$predicted)
+        }
+        x
+      },
+
+      .findPosteriorCols = function(nms) {
+        patterns <- c(
+          "^Class[_\\.]?[0-9]+$", "^class[_\\.]?[0-9]+$",
+          "^C[0-9]+$", "^c[0-9]+$", "^p[0-9]+$", "^P[0-9]+$",
+          "^prob(?:ability)?[_\\.]?[0-9]+$", "^posterior[_\\.]?[0-9]+$"
+        )
+        hits <- unique(unlist(lapply(patterns, function(p) grep(p, nms))))
+        nms[hits]
+      },
+
       .computeThreeStep = function() {
         auxName <- self$options$auxVar
         if (is.null(auxName) || !nzchar(auxName))
           return(NULL)
-        
-        dat <- as.data.frame(self$data)
+
+        dat <- private$.data_raw()
         if (!(auxName %in% names(dat)))
           return(list(msg = sprintf("[3-step] '%s' not found in data.", auxName)))
-        
-        # posterior 가져오기
-        ind <- self$classProbabilities$individual
-        
-        # posterior 열 탐색
-        .findPosteriorCols <- function(nms) {
-          pats <- c(
-            "^Class[_\\.]?[0-9]+$", "^class[_\\.]?[0-9]+$",
-            "^C[0-9]+$", "^c[0-9]+$", "^p[0-9]+$", "^P[0-9]+$",
-            "^prob(?:ability)?[_\\.]?[0-9]+$", "^posterior[_\\.]?[0-9]+$"
-          )
-          hits <- unique(unlist(lapply(pats, function(p) grep(p, nms))))
-          nms[hits]
-        }
-        pcols <- .findPosteriorCols(names(ind))
+
+        cp <- self$classProbabilities
+        ind <- cp$individual
+
+        pcols <- private$.findPosteriorCols(names(ind))
         if (length(pcols) == 0) {
           num <- names(ind)[vapply(ind, is.numeric, TRUE)]
-          cand <- setdiff(num, c("id","ID","predicted","Predicted"))
+          cand <- setdiff(num, c("id", "ID", "predicted", "Predicted"))
           if (length(cand) > 1) {
             S <- rowSums(ind[, cand, drop = FALSE], na.rm = TRUE)
             if (all(is.finite(S)) && mean(abs(S - 1)) < 1e-3)
@@ -129,23 +215,22 @@ lcgmClass <- if (requireNamespace('jmvcore', quietly = TRUE))
         }
         if (length(pcols) == 0)
           return(list(msg = "[3-step] posterior columns not found (tried C1/Class_1/p1/etc.)."))
-        
+
         K <- length(pcols)
         cls_levels <- seq_len(K)
-        
-        # ---- 보조변수 타입 결정 ----
+
         yraw <- dat[[auxName]]
         n <- NROW(yraw)
         if (n != NROW(ind))
           return(list(msg = "[3-step] data/posterior row mismatch."))
-        
+
         notes <- character(0)
         is_cat_like <- function(x) {
           if (!is.numeric(x)) return(FALSE)
           ux <- sort(unique(x[is.finite(x)]))
           length(ux) <= 6 && all(abs(ux - round(ux)) < 1e-8)
         }
-        
+
         if (is.factor(yraw) || is.ordered(yraw) || is.character(yraw) || is.logical(yraw)) {
           ytype <- "categorical"; yfac <- as.factor(yraw)
         } else if (is_cat_like(yraw)) {
@@ -156,56 +241,50 @@ lcgmClass <- if (requireNamespace('jmvcore', quietly = TRUE))
         } else {
           return(list(msg = sprintf("[3-step] Unsupported type for '%s'.", auxName)))
         }
-        
-        # ---- 결측 처리: y 결측이면 해당 행 가중치 0 ----
+
         if (ytype == "numeric") {
           y <- yraw; wmask <- is.finite(y)
         } else {
           y <- yfac; wmask <- !is.na(y)
         }
         for (pc in pcols) ind[[pc]][!wmask] <- 0
-        
-        # =========================
-        # BCH (연속형)
-        # =========================
+
         if (ytype == "numeric") {
           long <- lapply(seq_len(K), function(k) {
             data.frame(class = factor(k, levels = cls_levels),
-                       y = y, w = ind[[pcols[k]]])
+                       y = yraw,
+                       w = ind[[pcols[k]]],
+                       stringsAsFactors = FALSE)
           })
           long <- do.call(rbind, long)
-          
+
           eff_nk <- tapply(long$w, long$class, sum)
           if (any(eff_nk < 1e-6))
             notes <- c(notes, "[warn] One or more classes have (near-)zero effective weight for the distal variable.")
           if (stats::var(long$y[long$w > 0], na.rm = TRUE) < 1e-10)
             notes <- c(notes, "[warn] Near-zero variance in distal variable (BCH may be unreliable).")
-          
-          # 클래스별 평균/분산/SE/N_eff
+
           wmean <- tapply(long$y * long$w, long$class, sum) / pmax(eff_nk, .Machine$double.eps)
-          # 가중 분산
-          wvar <- sapply(levels(long$class), function(k) {
+          wvar <- vapply(levels(long$class), function(k) {
             idx <- long$class == k
             wk <- long$w[idx]; yk <- long$y[idx]
             mk <- if (eff_nk[k] > 0) sum(wk * yk) / eff_nk[k] else NA_real_
             if (!is.finite(mk) || eff_nk[k] <= 0) return(NA_real_)
             sum(wk * (yk - mk)^2) / eff_nk[k]
-          })
+          }, numeric(1))
           wse <- sqrt(wvar / pmax(eff_nk, 1))
-          
-          # 전체 F 근사
+
           wbar <- sum(long$y * long$w) / sum(long$w)
-          ssb  <- sum(eff_nk * (wmean - wbar)^2, na.rm=TRUE)
+          ssb  <- sum(eff_nk * (wmean - wbar)^2, na.rm = TRUE)
           long$gmean <- wmean[as.character(long$class)]
-          ssw  <- sum(long$w * (long$y - long$gmean)^2, na.rm=TRUE)
+          ssw  <- sum(long$w * (long$y - long$gmean)^2, na.rm = TRUE)
           dfb  <- K - 1
-          dfw  <- max(1, sum(eff_nk, na.rm=TRUE) - K)
+          dfw  <- max(1, sum(eff_nk, na.rm = TRUE) - K)
           msb  <- ssb / dfb
           msw  <- ssw / dfw
           Fst  <- if (msw > 0) msb / msw else Inf
           pF   <- tryCatch(stats::pf(Fst, dfb, dfw, lower.tail = FALSE), error = function(e) NA_real_)
-          
-          # 텍스트: 클래스별
+
           lines <- c(
             "3-step analysis (BCH/DCAT)",
             "=== 3-STEP auxiliary (tidySEM, BCH_basic) ===",
@@ -214,16 +293,17 @@ lcgmClass <- if (requireNamespace('jmvcore', quietly = TRUE))
                     paste(paste0("C", names(wmean), "=", round(wmean, 3)), collapse = ", ")),
             sprintf("Wald/ANOVA approx: F(%d,%.1f)=%.3f, p=%.4f", dfb, dfw, Fst, pF)
           )
-          
-          # 쌍별 비교: z, p, p_BH, p_Bonf, Cohen's d
+
           if (K >= 2) {
-            pair_lab <- c(); p_raw <- c(); zvals <- c(); dvals <- c()
-            for (a in 1:(K-1)) for (b in (a+1):K) {
+            pair_lab <- character()
+            p_raw <- numeric()
+            zvals <- numeric()
+            dvals <- numeric()
+            for (a in 1:(K - 1)) for (b in (a + 1):K) {
               za <- (wmean[a] - wmean[b]) / sqrt(wse[a]^2 + wse[b]^2)
-              pa <- 2*stats::pnorm(-abs(za))
-              # Cohen's d (가중 pooled SD)
-              spooled <- sqrt( ((eff_nk[a]-1)*wvar[a] + (eff_nk[b]-1)*wvar[b]) /
-                                 pmax(eff_nk[a]+eff_nk[b]-2, 1) )
+              pa <- 2 * stats::pnorm(-abs(za))
+              spooled <- sqrt(((eff_nk[a] - 1) * wvar[a] + (eff_nk[b] - 1) * wvar[b]) /
+                                pmax(eff_nk[a] + eff_nk[b] - 2, 1))
               d_ab <- (wmean[a] - wmean[b]) / spooled
               pair_lab <- c(pair_lab, sprintf("%d vs %d", a, b))
               p_raw    <- c(p_raw, pa)
@@ -238,56 +318,57 @@ lcgmClass <- if (requireNamespace('jmvcore', quietly = TRUE))
                                         pair_lab[i], zvals[i], p_raw[i], p_bh[i], p_bonf[i], dvals[i]))
             }
           }
-          
+
           if (length(notes)) lines <- c(lines, notes)
           return(list(text = paste(lines, collapse = "\n")))
         }
-        
-        # =========================
-        # DCAT (범주형)
-        # =========================
+
         cats <- levels(y)
         W <- matrix(0, nrow = K, ncol = length(cats),
                     dimnames = list(paste0("C", cls_levels), cats))
         for (k in seq_len(K)) {
           for (j in seq_along(cats)) {
-            W[k, j] <- sum( (y == cats[j]) * ind[[pcols[k]]] )
+            W[k, j] <- sum((y == cats[j]) * ind[[pcols[k]]])
           }
         }
-        
-        # 전체 χ² + Cramér's V
-        rowsum <- rowSums(W, na.rm=TRUE)
-        colsum <- colSums(W, na.rm=TRUE)
-        grand  <- sum(rowsum, na.rm=TRUE)
+
+        rowsum <- rowSums(W, na.rm = TRUE)
+        colsum <- colSums(W, na.rm = TRUE)
+        grand  <- sum(rowsum, na.rm = TRUE)
         E <- outer(rowsum, colsum) / ifelse(grand > 0, grand, NA_real_)
         if (any(E < 1))
           notes <- c(notes, "[warn] Some expected weighted counts < 1 (chi-square may be inaccurate).")
         if (mean(E < 5) > 0.2)
           notes <- c(notes, "[note] >20% of expected weighted counts < 5 (use caution).")
-        
-        chi  <- sum((W - E)^2 / pmax(E, .Machine$double.eps), na.rm=TRUE)
+
+        chi  <- sum((W - E)^2 / pmax(E, .Machine$double.eps), na.rm = TRUE)
         df   <- (K - 1) * (length(cats) - 1)
-        pchi <- stats::pchisq(chi, df=df, lower.tail=FALSE)
-        Vall <- sqrt( chi / (grand * max(1, min(K-1, length(cats)-1))) )
-        
+        pchi <- stats::pchisq(chi, df = df, lower.tail = FALSE)
+        Vall <- sqrt(chi / (grand * max(1, min(K - 1, length(cats) - 1))))
+
         lines <- c(
           "3-step analysis (BCH/DCAT)",
           "=== 3-STEP auxiliary (tidySEM, DCAT) ===",
           sprintf("[Distal: %s, categorical] K=%d, J=%d", auxName, K, ncol(W)),
           sprintf("Wald/Chi-square: X^2(%d)=%.3f, p=%.4f, Cramer's V=%.3f", df, chi, pchi, Vall)
         )
-        
-        # 쌍별 2×C: χ², p, 보정 p, V
+
         if (K >= 2) {
-          pair_lab <- c(); p_raw <- c(); chis <- c(); df2 <- c(); Vpair <- c()
-          for (a in 1:(K-1)) for (b in (a+1):K) {
+          pair_lab <- character()
+          p_raw <- numeric()
+          chis <- numeric()
+          df2 <- numeric()
+          Vpair <- numeric()
+          for (a in 1:(K - 1)) for (b in (a + 1):K) {
             sub <- rbind(W[a, ], W[b, ])
-            rs  <- rowSums(sub); cs <- colSums(sub); g <- sum(rs)
+            rs  <- rowSums(sub)
+            cs  <- colSums(sub)
+            g <- sum(rs)
             Eab <- outer(rs, cs) / ifelse(g > 0, g, NA_real_)
-            chiab <- sum((sub - Eab)^2 / pmax(Eab, .Machine$double.eps), na.rm=TRUE)
+            chiab <- sum((sub - Eab)^2 / pmax(Eab, .Machine$double.eps), na.rm = TRUE)
             dfab  <- ncol(W) - 1
-            pab   <- stats::pchisq(chiab, df=dfab, lower.tail=FALSE)
-            Vab   <- sqrt( chiab / pmax(g, .Machine$double.eps) )  # 2×C → min(r-1,c-1)=1
+            pab   <- stats::pchisq(chiab, df = dfab, lower.tail = FALSE)
+            Vab   <- sqrt(chiab / pmax(g, .Machine$double.eps))
             pair_lab <- c(pair_lab, sprintf("%d vs %d", a, b))
             p_raw    <- c(p_raw, pab)
             chis     <- c(chis, chiab)
@@ -302,17 +383,18 @@ lcgmClass <- if (requireNamespace('jmvcore', quietly = TRUE))
                                       pair_lab[i], df2[i], chis[i], p_raw[i], p_bh[i], p_bonf[i], Vpair[i]))
           }
         }
-        
+
         if (length(notes)) lines <- c(lines, notes)
-        return(list(text = paste(lines, collapse = "\n")))
+        list(text = paste(lines, collapse = "\n"))
       },
-      
+
       .init = function() {
+        private$.cacheReset()
         private$.htmlwidget <- HTMLWidget$new()
-        
+
         if (is.null(self$data) || is.null(self$options$vars))
           self$results$instructions$setVisible(TRUE)
-        
+
         self$results$instructions$setContent(
           private$.htmlwidget$generate_accordion(
             title   = "Instructions",
@@ -330,94 +412,99 @@ lcgmClass <- if (requireNamespace('jmvcore', quietly = TRUE))
             )
           )
         )
-        
+
         if (isTRUE(self$options$plot1))
           self$results$plot1$setSize(self$options$width1, self$options$height1)
-        
+
         if (isTRUE(self$options$plot))
           self$results$plot$setSize(self$options$width, self$options$height)
-        
+
         if (isTRUE(self$options$plot2))
           self$results$plot2$setSize(self$options$width2, self$options$height2)
       },
-      
+
       .run = function() {
         if (is.null(self$options$vars) || length(self$options$vars) < 3)
           return()
-        
+
+        private$.cacheReset()
+
         self$results$progressBarHTML$setVisible(TRUE)
-        html <- progressBarH(5,  100, 'Starting analysis...')
+        on.exit({
+          self$results$progressBarHTML$setVisible(FALSE)
+          private$.cacheReset(c("data_raw", "data_model"))
+        }, add = TRUE)
+
+        html <- progressBarH(5, 100, 'Starting analysis...')
         self$results$progressBarHTML$setContent(html)
         private$.checkpoint()
-        
+
         set.seed(1234)
-        
+
         if (isTRUE(self$options$desc)) {
           html <- progressBarH(15, 100, 'Computing descriptives...')
           self$results$progressBarHTML$setContent(html)
           private$.checkpoint()
           private$.populateDescTable()
         }
-        
+
         if (isTRUE(self$options$fit)) {
           html <- progressBarH(30, 100, 'Calculating fit statistics...')
           self$results$progressBarHTML$setContent(html)
           private$.checkpoint()
           private$.populateFitTable()
         }
-        
+
         if (isTRUE(self$options$est)) {
           html <- progressBarH(45, 100, 'Extracting parameter estimates...')
           self$results$progressBarHTML$setContent(html)
           private$.checkpoint()
           private$.populateEST()
         }
-        
+
         if (isTRUE(self$options$cp)) {
           html <- progressBarH(60, 100, 'Computing class probabilities...')
           self$results$progressBarHTML$setContent(html)
           private$.checkpoint()
           private$.populateClassSizeTable()
         }
-        
+
         if (isTRUE(self$options$mem)) {
           html <- progressBarH(70, 100, 'Listing class members...')
           self$results$progressBarHTML$setContent(html)
           private$.checkpoint()
           private$.populateClassMemberTable()
         }
-        
+
         if (isTRUE(self$options$plot2)) {
           html <- progressBarH(80, 100, 'Creating class size plot...')
           self$results$progressBarHTML$setContent(html)
           private$.checkpoint()
           private$.setPlot2()
         }
-        
+
         if (isTRUE(self$options$plot1)) {
           html <- progressBarH(88, 100, 'Preparing density plot...')
           self$results$progressBarHTML$setContent(html)
           private$.checkpoint()
           private$.setPlot1()
         }
-        
+
         if (isTRUE(self$options$plot)) {
           html <- progressBarH(96, 100, 'Generating growth plot...')
           self$results$progressBarHTML$setContent(html)
           private$.checkpoint()
           private$.setPlot()
         }
-        
-        # ---------- 3-STEP 실행 ----------
+
         if (isTRUE(self$options$use3step) && !is.null(self$options$auxVar)) {
           html <- progressBarH(98, 100, 'Running 3-step auxiliary (BCH/DCAT)...')
           self$results$progressBarHTML$setContent(html)
           private$.checkpoint()
-          
+
           res3 <- private$.computeThreeStep()
-          
-          sep_line <- strrep("━", 60)  # 굵은 유니코드 줄
-          
+          sep_line <- strrep("━", 60)
+
           if (is.null(res3)) {
             self$results$threeStep$setContent(
               paste0(sep_line, "\n[3-step] No auxiliary variable specified.\n", sep_line)
@@ -435,60 +522,59 @@ lcgmClass <- if (requireNamespace('jmvcore', quietly = TRUE))
             )
           }
         }
-        
-        html <- progressBarH(100,100, 'Analysis complete!')
+
+        html <- progressBarH(100, 100, 'Analysis complete!')
         self$results$progressBarHTML$setContent(html)
         private$.checkpoint()
-        self$results$progressBarHTML$setVisible(FALSE)
       },
-      
+
       .populateDescTable = function() {
         vars  <- self$options$vars
         table <- self$results$desc
-        d     <- as.data.frame(self$desc)
-        for (i in seq_along(vars))
-          table$addRow(rowKey = vars[i], values = as.list(d[i,2:8]))
+        desc_df <- self$desc
+        for (i in seq_along(vars)) {
+          row <- desc_df[vars[i], , drop = FALSE]
+          if (nrow(row) == 0)
+            next
+          table$addRow(rowKey = vars[i], values = as.list(row[1, c("n", "missing", "mean", "median", "sd", "min", "max")]))
+        }
       },
-      
+
       .populateFitTable = function() {
         table <- self$results$fit
         df    <- as.data.frame(t(self$fit))
         for (nm in rownames(df))
-          table$addRow(rowKey = nm, values = list(value = df[nm,1]))
+          table$addRow(rowKey = nm, values = list(value = df[nm, 1]))
       },
-      
+
       .populateEST = function() {
         table <- self$results$est
-        e     <- as.data.frame(self$parameters)
-        for (nm in rownames(e))
-          table$addRow(rowKey = nm, values = list(
-            cat  = e[nm,1],
-            lhs  = e[nm,2],
-            est  = e[nm,3],
-            se   = e[nm,4],
-            p    = e[nm,5],
-            ci   = e[nm,6],
-            na   = e[nm,7]
-          ))
-      },
-      
-      .populateClassSizeTable = function() {
-        table <- self$results$cp
-        individual_data <- self$classProbabilities$individual
-        predicted_classes <- individual_data$predicted
-        class_counts <- table(predicted_classes)
-        total_n <- sum(class_counts)
-        
-        for (class_num in sort(unique(predicted_classes))) {
-          count_val <- as.integer(class_counts[as.character(class_num)])
-          prop_val <- round(count_val / total_n, 3)
-          table$addRow(rowKey = as.integer(class_num), values = list(
-            count = count_val,
-            prop  = prop_val
+        e     <- self$parameters
+        for (i in seq_len(nrow(e))) {
+          table$addRow(rowKey = rownames(e)[i], values = list(
+            cat = e$Category[i],
+            lhs = e$lhs[i],
+            est = e$est[i],
+            se  = e$se[i],
+            p   = e$pval[i],
+            ci  = e$confint[i],
+            na  = e$name[i]
           ))
         }
       },
-      
+
+      .populateClassSizeTable = function() {
+        table <- self$results$cp
+        cp    <- self$classProbabilities
+        summary_df <- cp$summary
+        for (i in seq_len(nrow(summary_df))) {
+          table$addRow(rowKey = summary_df$Class[i], values = list(
+            count = summary_df$Count[i],
+            prop  = summary_df$Proportion[i]
+          ))
+        }
+      },
+
       .populateClassMemberTable = function() {
         table <- self$results$mem
         mem   <- self$classProbabilities$individual
@@ -497,25 +583,20 @@ lcgmClass <- if (requireNamespace('jmvcore', quietly = TRUE))
           table$setValues(as.factor(mem$predicted))
         }
       },
-      
+
       .setPlot2 = function() {
-        individual_data <- self$classProbabilities$individual
-        predicted_classes <- individual_data$predicted
-        class_counts <- table(predicted_classes)
-        total_n <- sum(class_counts)
-        
+        cp <- self$classProbabilities
         plot_data <- data.frame(
-          Class = factor(names(class_counts), levels = sort(as.numeric(names(class_counts)))),
-          Count = as.numeric(class_counts),
-          Proportion = round(as.numeric(class_counts) / total_n, 3),
-          Percentage = round(as.numeric(class_counts) / total_n * 100, 1)
+          Class = factor(cp$summary$Class, levels = sort(cp$summary$Class)),
+          Count = cp$summary$Count,
+          Proportion = cp$summary$Proportion,
+          Percentage = round(cp$summary$Proportion * 100, 1)
         )
-        
         self$results$plot2$setState(plot_data)
       },
-      
+
       .setPlot1 = function() {
-        df   <- as.data.frame(self$data)
+        df   <- private$.data_raw()
         vars <- self$options$vars
         if (is.null(vars) || length(vars) < 1) return()
         isNum <- vapply(df[vars], is.numeric, TRUE)
@@ -529,13 +610,14 @@ lcgmClass <- if (requireNamespace('jmvcore', quietly = TRUE))
                         idvar     = "id",
                         timevar   = "time")
         long$time <- factor(long$time, labels = xvars)
+        long <- long[is.finite(long$value), , drop = FALSE]
         self$results$plot1$setState(long)
       },
-      
+
       .setPlot = function() {
         self$results$plot$setState(self$res)
       },
-      
+
       .plot2 = function(image, ggtheme, theme, ...) {
         if (is.null(image$state)) return(FALSE)
         plot_data <- image$state
@@ -559,19 +641,18 @@ lcgmClass <- if (requireNamespace('jmvcore', quietly = TRUE))
           scale_y_continuous(expand = expansion(mult = c(0, 0.15)))
         print(p + ggtheme); TRUE
       },
-      
+
       .plot1 = function(image, ggtheme, theme, ...) {
         if (is.null(image$state)) return(FALSE)
         long <- image$state
-        long <- long[is.finite(long$value), , drop = FALSE]
         p <- ggplot(long, aes(x = value)) +
           geom_density() +
-          facet_wrap(~ time, ncol = 2) +   
+          facet_wrap(~ time, ncol = 2) +
           theme_bw()
         print(p + ggtheme)
         TRUE
       },
-      
+
       .plot = function(image, ggtheme, theme, ...) {
         if (is.null(image$state)) return(FALSE)
         p <- tidySEM::plot_growth(image$state,
@@ -583,11 +664,10 @@ lcgmClass <- if (requireNamespace('jmvcore', quietly = TRUE))
   )
 
 
-# Progress Bar HTML (R/progressBarH.R)
 progressBarH <- function(progress = 0, total = 100, message = '') {
   percentage <- round(progress / total * 100)
   width      <- 400 * percentage / 100
-  
+
   html <- paste0(
     '<div style="text-align: center; padding: 20px;">',
     '<div style="width: 400px; height: 20px; border: 1px solid #ccc;',
@@ -601,6 +681,6 @@ progressBarH <- function(progress = 0, total = 100, message = '') {
     '</div>',
     '</div>'
   )
-  
-  return(html)
+
+  html
 }

--- a/analysis/lcgm_memory_leak_analysis.md
+++ b/analysis/lcgm_memory_leak_analysis.md
@@ -1,0 +1,26 @@
+# Memory Leak Risk Assessment for `lcgm.b.R`
+
+## Overview
+The `lcgmClass` R6 analysis class drives the jamovi latent class growth modeling (LCGM) module. It caches expensive tidySEM objects, populates jamovi tables, and stores plot states inside the results tree. The patterns below flag code paths that can accumulate large objects in memory or prevent garbage collection when the analysis is rerun with different options or datasets.
+
+## Potential Memory Leak Patterns
+
+### 1. Long-lived private caches that are never invalidated
+`lcgmClass` memoises every expensive computation (`mx_growth_mixture`, descriptives, fit statistics, parameter tables, and class probabilities) inside private fields such as `private$.res_cache`, `private$.desc_cache`, `private$.fit_cache`, `private$.para_cache`, and `private$.cp_cache`.【F:R/lcgm.b.R†L12-L82】 Once these caches are populated, no code path resets them to `NULL`; the class invokes `private$.checkpoint()` throughout `.run()`, but the method is not defined in this class or its base type. Consequently, the first set of results stays pinned in memory for the lifetime of the analysis object, even after the user changes options or re-runs the model with a different dataset. Because `mx_growth_mixture()` returns an `MxModel` that retains data, gradients, and external pointers, the absence of cache invalidation is a strong leak candidate when analysts iterate on large models.
+
+### 2. Retaining full individual-level posterior data irrespective of UI options
+`classProbabilities` materialises the full per-case posterior table returned by `tidySEM::class_prob()` and stores it in `private$.cp_cache$individual`, together with a summary table.【F:R/lcgm.b.R†L52-L72】 The cache is populated as soon as any caller (for example the 3-step auxiliary routine) touches the active binding, even if the analyst has not requested the class-probability tables or member listings. Because the cached data frame mirrors the input sample size × number-of-classes matrix, it can be very large; without a corresponding invalidation strategy, the object will persist until the entire analysis instance is destroyed.
+
+### 3. Results tables populated incrementally without clearing
+Helper routines such as `.populateDescTable()`, `.populateFitTable()`, `.populateEST()`, and `.populateClassSizeTable()` call `table$addRow()` for every run but never clear or overwrite previous rows.【F:R/lcgm.b.R†L445-L488】 If jamovi does not deduplicate rows with the same key, each rerun appends another copy of the data to the results object. This steady growth can inflate the analysis payload and prevent old rows from being released, especially when analysts iterate over many class counts or auxiliary variables in a single session.
+
+### 4. Storing heavyweight model objects in image state
+`.setPlot()` injects `self$res`—the full `MxModel` produced by `mx_growth_mixture()`—directly into the image state, which jamovi keeps alive for plotting callbacks.【F:R/lcgm.b.R†L535-L580】 Because the plot callbacks simply forward the model to `tidySEM::plot_growth()`, the image result now owns another strong reference to the already cached `MxModel`. Unless the cache is cleared, both the private field and the image state retain the same heavyweight object, making it impossible for the garbage collector to reclaim memory between runs.
+
+## Recommendations
+- Implement a concrete `private$.checkpoint()` (or similar) that resets all caches whenever `.run()` is invoked or when key options/data change.
+- Lazily compute class probabilities only when the related UI elements are enabled, and drop the cached posterior matrix after dependent outputs have been constructed.
+- Replace `table$addRow()` with `table$setRow()` or clear table contents before repopulating to prevent unbounded growth of jamovi result tables.
+- Serialize only the lightweight data required for plotting (e.g., predicted trajectories or summary statistics) instead of persisting the full `MxModel` inside result states.
+
+These changes would prevent large tidySEM artifacts and duplicated result tables from accumulating in memory across iterative analysis workflows.


### PR DESCRIPTION
## Summary
- refactor lcgmClass to centralize cache management and data reuse helpers, preventing stale large objects from persisting across runs
- streamline 3-step auxiliary computation to reuse cached probabilities and guard against posterior/data mismatches while preserving behaviour
- update table and plot population routines to consume the new cached summaries without duplicating large data frames

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e71ee2cb74832c98f4fb1c07673c99